### PR TITLE
Typo in _send

### DIFF
--- a/logger.c
+++ b/logger.c
@@ -129,7 +129,7 @@ _close_fake(struct logger *logger, int oldFd) {
 static int
 _send(struct logger *logger, char *buf, int len) {
 	int fd = logger->fd;
-	if (fd != -1)
+	if (fd == -1)
 		return 1;
 
 	if (send(fd, buf, len, 0) == -1) {


### PR DESCRIPTION
Error checking before send() was(fd != -1) instead of (fd == -1).
I tried using this lib to write to /dev/log, and it didn't work until I fixed this. Worked perfectly once I changed it